### PR TITLE
Bugfix: constructor-super should handle decorators with arguments

### DIFF
--- a/src/rules/constructor-super.js
+++ b/src/rules/constructor-super.js
@@ -23,9 +23,11 @@ function isAutoExtended(classNode) {
     // Look to see if we have a class decorator that extends from a super-class
     const twistDecorators = getTwistConfiguration().decorators || {};
     const isExtendedDecorator = decorator => {
-        const name = decorator.expression && decorator.expression.name;
-        if (name && twistDecorators[name]) {
-            return twistDecorators[name].inherits !== undefined;
+        const expr = decorator.expression;
+        const identifier = (expr.type === 'Identifier' && expr)
+            || (expr.type === 'CallExpression' && expr.callee.type === 'Identifier' && expr.callee);
+        if (identifier && twistDecorators[identifier.name]) {
+            return twistDecorators[identifier.name].inherits !== undefined;
         }
         return false;
     };
@@ -52,6 +54,7 @@ module.exports = {
             const isConstructorFunction = node.type === 'FunctionExpression'
                 && node.parent.type === 'MethodDefinition'
                 && node.parent.kind === 'constructor';
+
             if (isConstructorFunction) {
                 let classNode = node.parent.parent.parent;
                 if (!classNode.superClass && isAutoExtended(classNode)) {

--- a/test/lib/rules/constructor-super.js
+++ b/test/lib/rules/constructor-super.js
@@ -61,6 +61,25 @@ ruleTester.run('constructor-super', constructorSuper, {
             }
         }
         `
+    }, {
+        code: `
+        @Store({ mutable: true })
+        class MyStore {
+            constructor() {
+                super();
+                this.x = 2;
+            }
+        }
+        `
+    }, {
+        code: `
+        @Prototype({ x: 3 })
+        class MyClass {
+            constructor() {
+                this.x = 2;
+            }
+        }
+        `
     } ],
     invalid: [ {
         code: `
@@ -79,6 +98,35 @@ ruleTester.run('constructor-super', constructorSuper, {
     }, {
         code: `
         @Prototype
+        class MyClass {
+            constructor() {
+                super();
+                this.x = 2;
+            }
+        }
+        `,
+        errors: [ {
+            message: `Unexpected 'super()'.`,
+            line: 5
+        } ],
+        parser: 'babel-eslint'
+    }, {
+        code: `
+        @Store({ mutable: true })
+        class MyStore {
+            constructor() {
+                this.x = 2;
+            }
+        }
+        `,
+        errors: [ {
+            message: `Expected to call 'super()'.`,
+            line: 4
+        } ],
+        parser: 'babel-eslint'
+    }, {
+        code: `
+        @Prototype({ x: 3 })
         class MyClass {
             constructor() {
                 super();


### PR DESCRIPTION
### What does this PR do?

Fixes bug where constructor-super failed to recognize decorators that take arguments.

### Checklist

- [ ] I've read the [contribution guidelines](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [ ] An issue has been created for this PR
- [ ] Title begins with one of the following: `Fix:`, `Update:`, `Breaking:`, or `New:`
- [ ] Title ends with a reference to the related issue(s): `(fixes #issue)` or `(refs #issue)`
- [ ] Linting and unit tests all pass (`npm test`)
- [ ] PR includes new unit tests as necessary (or will be submitted as a separate PR)
- [ ] PR includes documentation as necessary (or will be forthcoming in a separate PR)
